### PR TITLE
Fix bluetooth connection issues with ESPHome 2023.11

### DIFF
--- a/components/danfoss_eco/device.cpp
+++ b/components/danfoss_eco/device.cpp
@@ -20,6 +20,7 @@ namespace esphome
       this->properties = {this->p_pin, this->p_battery, this->p_temperature, this->p_settings, this->p_errors, this->p_secret_key};
       // pretend, we have already discovered the device
       copy_address(this->parent()->get_address(), this->parent()->get_remote_bda());
+      this->parent()->set_state(ClientState::INIT);
     }
 
     void Device::loop()
@@ -206,7 +207,7 @@ namespace esphome
 
     void Device::connect()
     {
-      if (this->node_state == ClientState::ESTABLISHED)
+      if (this->node_state == ClientState::INIT || this->node_state == ClientState::ESTABLISHED)
       {
         return;
       }
@@ -221,7 +222,7 @@ namespace esphome
       }
       // gap scanning interferes with connection attempts, which results in esp_gatt_status_t::ESP_GATT_ERROR (0x85)
       esp_ble_gap_stop_scanning();
-      this->parent()->set_state(ClientState::DISCOVERED); // this will cause ble_client to attempt connect() from its loop()
+      this->parent()->set_state(ClientState::READY_TO_CONNECT); // this will cause ble_client to attempt connect() from its loop()
     }
 
     void Device::disconnect()


### PR DESCRIPTION
Fixes bluetooth connection issues occuring after ESPHome 2023.11 update, also mentioned in #18.

I think the issue is caused by this change in esphome: esphome/esphome#5704.

You can try the fix by setting:
``` yaml
external_components:
  - source: github://ckoca/esphome-danfoss-eco@fix/esphome-2023.11-compatibility
```
