### PR TITLE
Fix uninitialized target temperature

### DIFF
--- a/components/danfoss_eco/my_component.h
+++ b/components/danfoss_eco/my_component.h
@@ -19,6 +19,12 @@ namespace esphome
         class MyComponent : public Climate, public PollingComponent, public enable_shared_from_this<MyComponent>
         {
         public:
+            MyComponent()
+            {
+                // TODO: remove this assignment after this unitialized variable bug is fixed in esphome
+                Climate::target_temperature = NAN;
+            }
+
             float get_setup_priority() const override { return setup_priority::DATA; }
 
             ClimateTraits traits() override


### PR DESCRIPTION
Fixes an uninitialized variable bug that is sometimes causing the target temperature to temporarily have absurd values upon restarting the ESP32 processor. For example:

![image](https://github.com/dmitry-cherkas/esphome-danfoss-eco/assets/32613747/787ab5d4-7d40-4232-9979-8f04faf82677)

I believe that the bug is actually in ESPHome implementation and I am also going to provide a fix in https://github.com/esphome/esphome repository. Once that fix lands I will remove this temporary fix here.